### PR TITLE
Add AWS resource detector entry points

### DIFF
--- a/sdk-extension/opentelemetry-sdk-extension-aws/pyproject.toml
+++ b/sdk-extension/opentelemetry-sdk-extension-aws/pyproject.toml
@@ -30,6 +30,13 @@ dependencies = [
 [project.entry-points.opentelemetry_id_generator]
 xray = "opentelemetry.sdk.extension.aws.trace.aws_xray_id_generator:AwsXRayIdGenerator"
 
+[project.entry-points.opentelemetry_resource_detector]
+aws_ec2 = "opentelemetry.sdk.extension.aws.resource.ec2:AwsEc2ResourceDetector"
+aws_ecs = "opentelemetry.sdk.extension.aws.resource.ecs:AwsEcsResourceDetector"
+aws_eks = "opentelemetry.sdk.extension.aws.resource.eks:AwsEksResourceDetector"
+aws_elastic_beanstalk = "opentelemetry.sdk.extension.aws.resource.beanstalk:AwsBeanstalkResourceDetector"
+aws_lambda = "opentelemetry.sdk.extension.aws.resource._lambda:AwsLambdaResourceDetector"
+
 [project.urls]
 Homepage = "https://github.com/open-telemetry/opentelemetry-python-contrib/tree/main/sdk-extension/opentelemetry-sdk-extension-aws"
 


### PR DESCRIPTION
# Description
The AWS resource detectors currently are not picked up when using the new `OTEL_EXPERIMENTAL_RESOURCE_DETECTORS` environment variable because they are not registered under the [opentelemetry_resource_detector](https://github.com/open-telemetry/opentelemetry-python/blob/721beb8b530e7a830c1e27b70c2fb9af6465baf1/opentelemetry-sdk/src/opentelemetry/sdk/resources/__init__.py#L191-L194) entry point.

This PR adds the relevant section to the sdk-aws pyproject.toml file to allow the resource detectors to be used.

Fixes #1861, #2370

## Type of change
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Added the following line to my Dockerfile in an otel-instrumented test Flask app:
```
RUN echo "\n\n[opentelemetry_resource_detector]\naws_elastic_beanstalk =
opentelemetry.sdk.extension.aws.resource.beanstalk:AwsBeanstalkResourceDetector"
 >>
/usr/local/lib/python3.12/site-packages/opentelemetry_sdk_extension_aws-2.0.1.dist-info/entry_points.txt
```

The logs showed that the relevant resource attributes were set:
```
web_1             | {
web_1             |     "resource_metrics": [
web_1             |         {
web_1             |             "resource": {
web_1             |                 "attributes": {
web_1             |                     "telemetry.sdk.language": "python",
web_1             |                     "telemetry.sdk.name":
"opentelemetry",
web_1             |                     "telemetry.sdk.version": "1.20.0",
web_1             |                     "cloud.provider": "aws",
web_1             |                     "cloud.platform":
"aws_elastic_beanstalk",
web_1             |                     "service.name": "otel_test",
web_1             |                     "service.instance.id": "abc123",
web_1             |                     "service.namespace": "12345",
web_1             |                     "service.version": "0.0.1",
web_1             |                     "telemetry.auto.version": "0.41b0"
web_1             |                 },
web_1             |                 "schema_url": ""
web_1             |             },
web_1             |             "scope_metrics": [],
web_1             |             "schema_url": ""
web_1             |         }
web_1             |     ]
web_1             | }
```

# Does This PR Require a Core Repo Change?

- [ ] Yes. - Link to PR: 
- [x] No.

# Checklist:

See [contributing.md](https://github.com/open-telemetry/opentelemetry-python-contrib/blob/main/CONTRIBUTING.md) for styleguide, changelog guidelines, and more.

- [ ] Followed the style guidelines of this project
- [ ] Changelogs have been updated
- [ ] Unit tests have been added
- [ ] Documentation has been updated
